### PR TITLE
fix: frontend docker compose missing node modules on fresh setup

### DIFF
--- a/Frontend.dockerfile
+++ b/Frontend.dockerfile
@@ -12,7 +12,7 @@ RUN npm install
 COPY pkg-svcs/frontend/package.json /app/frontend/
 WORKDIR /app/frontend
 RUN npm install
-COPY pkg-svcs/frontend/ /app/frontend/
+COPY ./pkg-svcs/frontend/ /app/frontend/
 
 FROM source as builder
 WORKDIR /app/frontend 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - POSTGRES_PASSWORD=otlppassword
       - POSTGRES_DB=tododb
     healthcheck:
-      test: ["CMD-SHELL","pg_isready -U otlpuser" ]
+      test: ["CMD-SHELL","pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/pkg-svcs/backend/.env.sample
+++ b/pkg-svcs/backend/.env.sample
@@ -8,9 +8,9 @@ CORS_ORIGIN=true
 
 PG_HOST=postgresql
 PG_PORT=5432
-PG_DB=titus
-PG_USER=titus
-PG_PASS=titus
+PG_DB=tododb
+PG_USER=otlpuser
+PG_PASS=otlppassword
 
 SECRETS_STRATEGY=env
 SECRETS_PG_PASS=PG_PASS

--- a/pkg-svcs/frontend/package.json
+++ b/pkg-svcs/frontend/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "start:container" : "vite --host",
+    "start:container" : "npm install && npm run create:env && vite --host",
     "create:env": "rm -rf .env && node -r fs -e \"fs.copyFileSync('.env.sample', '.env', fs.constants.COPYFILE_EXCL)\""
   },
   "dependencies": {


### PR DESCRIPTION
1. On a new machine docker compose doesnt work for the frontend. The node modules are missing. This is fixed now.
2. Some refactoring on postgres healthcheck. 

closes #32 