### PR TITLE
189 - Add yarn.lock to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ node_modules
 
 **/.terragrunt-cache*
 **/.terraform.lock.hcl
+
+**/yarn.lock


### PR DESCRIPTION
Fixes #189 

Adding yarn.lock files to gitignore for those that prefer it to npm.

https://github.com/orgs/nearform/projects/14/views/1?pane=issue&itemId=22148449