### PR TITLE
185 - Fix PG_INFO in .env.sample

### DIFF
--- a/pkg-svcs/backend/.env.sample
+++ b/pkg-svcs/backend/.env.sample
@@ -6,7 +6,7 @@ API_PORT=3000
 
 CORS_ORIGIN=true
 
-PG_INFO="{\"database\": \"tododb\", \"username\": \"otlpuser\", \"password\": \"otlppassword\", \"host\": \"postgresql\", \"port\": 5432}"
+PG_INFO={"database": "tododb", "username": "otlpuser", "password": "otlppassword", "host": "postgresql", "port": 5432}
 
 SECRETS_STRATEGY=env
 SECRETS_PG_INFO=PG_INFO


### PR DESCRIPTION
Fixes #185 

Currently the .env.sample uses the following for PG_INFO:

```
PG_INFO="{\"database\": \"tododb\", \"username\": \"otlpuser\", \"password\": \"otlppassword\", \"host\": \"postgresql\", \"port\": 5432}"
```

it should use:

```
PG_INFO={"database": "tododb", "username": "otlpuser", "password": "otlppassword", "host": "postgresql", "port": 5432}
```

This way when the app bootstraps the .env file it will work. Might also be a good idea to not blindly overwrite the .env file in case people make local changes that they don't want to loose. This can be aggravating to engineers.

https://github.com/orgs/nearform/projects/14/views/1?pane=issue&itemId=21875106