### PR TITLE
186 - Setup network routing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
   postgresql:
     container_name: oltp_db
     image: postgres:14.2-alpine
+    hostname: postgresql.otlp-blueprint.local
     environment:
       - POSTGRES_USER=otlpuser
       - POSTGRES_PASSWORD=otlppassword
@@ -22,6 +23,7 @@ services:
 
   backend:
     container_name: backend
+    hostname: backend.otlp-blueprint.local
     build:
       context: ./
       dockerfile: Backend.dockerfile
@@ -43,6 +45,7 @@ services:
   
   frontend:
     container_name: frontend
+    hostname: frontend.otlp-blueprint.local
     build:
       context: ./
       dockerfile: Frontend.dockerfile
@@ -63,6 +66,7 @@ services:
 
   jaeger:
     image: jaegertracing/all-in-one:1.38.1
+    hostname: jaeger-service.otlp-blueprint.local
     ports:
       - "5775:5775/udp"
       - "6831:6831/udp"
@@ -79,6 +83,7 @@ services:
   
   collector:
     image: otel/opentelemetry-collector:0.56.0
+    hostname: collector.otlp-blueprint.local
     command: ["--config=/conf/collector-config.yaml"]
     volumes:
       - ./collector-config.yaml:/conf/collector-config.yaml


### PR DESCRIPTION
Fixes 186

Network routing isn't working out of the box because currently there are no hostnames on the docker containers.  By setting hostnames on all services we can use the service hostname for routing and also override this easily in production environments.