### PR TITLE
188 - Setup collectorconfig.yaml to use hostnames

### DIFF
--- a/collector-config.yaml
+++ b/collector-config.yaml
@@ -6,10 +6,8 @@ receivers:
         endpoint: 0.0.0.0:4318
         cors:
           allowed_origins:
-            - http://*
-            - https://*
-            - "*"
-
+            - http://*.otlp-blueprint.local
+            - https://*.otlp-blueprint.local
 exporters:
   jaeger:
     endpoint: "jaeger-service.otlp-blueprint.local:14250"


### PR DESCRIPTION
Fixes #188 

This removes the wildcards from the collector configs and instead uses proper hostnames once the hostnames have been setup in the docker-compose file.