### PR TITLE
203 - Rename network from jaeger-network to otlp-network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - POSTGRES_PASSWORD=otlppassword
       - POSTGRES_DB=tododb
     networks:
-      - jaeger-network
+      - otlp-network
     healthcheck:
       test: ["CMD-SHELL","pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}"]
       interval: 10s
@@ -35,7 +35,7 @@ services:
     ports:
       - "3000:3000"
     networks:
-      - jaeger-network
+      - otlp-network
     depends_on:
       - postgresql
       - jaeger
@@ -55,7 +55,7 @@ services:
     ports:
       - "8080:8080"
     networks:
-      - jaeger-network
+      - otlp-network
     depends_on:
       - backend
       - postgresql
@@ -79,7 +79,7 @@ services:
       - "14269:14269"
       - "9411:9411"
     networks:
-      - jaeger-network
+      - otlp-network
   
   collector:
     image: otel/opentelemetry-collector:0.56.0
@@ -97,9 +97,22 @@ services:
     depends_on:
       - jaeger
     networks:
-      - jaeger-network
+      - otlp-network
+
+  grafana:
+    image: grafana/grafana:9.3.2
+    volumes:
+      - ../shared/grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
+    environment:
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_DISABLE_LOGIN_FORM=true
+      - GF_FEATURE_TOGGLES_ENABLE=traceqlEditor
+    ports:
+      - "3000:3000"
+
 volumes:
   postgresql:
     external: false
 networks:
-      jaeger-network:
+      otlp-network:


### PR DESCRIPTION
Fixes #203 

Currently the network in the docker-compose is named jaeger-network, this can be confusing as we are trying to demo OpenTelemetry and not necessarily Jaeger. Renaming allows us to swap out tracing to other tools such as Tempo as well.
