### PR TITLE
Fixed missing terragrunt module mock outputs 

### DIFF
--- a/.github/workflows/deploy-ecr.yml
+++ b/.github/workflows/deploy-ecr.yml
@@ -1,9 +1,7 @@
-name: Deploy to ECR
+name: Deploy dev images to ECR
 
 on:
-  push:
-    branches: [ main ]
-  pull_request:
+  workflow_dispatch:
 
 jobs:
 

--- a/infrastructure/terraform/app/backend-td/otfp-be.json.tpl
+++ b/infrastructure/terraform/app/backend-td/otfp-be.json.tpl
@@ -29,12 +29,10 @@
       {
         "name": "PG_DB",
         "value": "${db_name}"
-      }
-    ],
-    "secrets": [
+      },
       {
         "name": "SECRETS_PG_INFO",
-        "valueFrom": "${database_secret_arn}"
+        "value": "${database_secret_arn}"
       }
     ],
     "portMappings": [

--- a/infrastructure/terragrunt/dev/us-east-1/app/backend-td/terragrunt.hcl
+++ b/infrastructure/terragrunt/dev/us-east-1/app/backend-td/terragrunt.hcl
@@ -25,6 +25,10 @@ dependency "rds" {
   # Mock outputs for plan to work
   mock_outputs = {
     secrets_arn  = "sfasdfasdfasdfas"
+    db_host = "mock.host"
+    db_port = "mock.db_port"
+    db_name = "mock.dbname"
+    db_username = "mock.username"
   }
 }
 
@@ -52,6 +56,7 @@ dependency "ecs_cluster" {
   # Mock outputs for plan to work
   mock_outputs = {
     ecs_cluster_id = "fasdfasfasdfasdfasdf"
+    ecs_service_discovery_namespace_id = "awawfawf"
   }
 }
 

--- a/infrastructure/terragrunt/dev/us-east-1/app/jaeger-all-in-one-td/terragrunt.hcl
+++ b/infrastructure/terragrunt/dev/us-east-1/app/jaeger-all-in-one-td/terragrunt.hcl
@@ -42,6 +42,7 @@ dependency "ecs_cluster" {
   # Mock outputs for plan to work
   mock_outputs = {
     ecs_cluster_id = "fasdfasfasdfasdfasdf"
+    ecs_service_discovery_namespace_id = "awawfawf"
   }
 }
 

--- a/infrastructure/terragrunt/dev/us-east-1/app/otel-collector-td/terragrunt.hcl
+++ b/infrastructure/terragrunt/dev/us-east-1/app/otel-collector-td/terragrunt.hcl
@@ -43,6 +43,7 @@ dependency "ecs_cluster" {
   # Mock outputs for plan to work
   mock_outputs = {
     ecs_cluster_id = "fasdfasfasdfasdfasdf"
+    ecs_service_discovery_namespace_id = "awawfawf"
   }
 }
 


### PR DESCRIPTION
+ task template with secrets extrapolation instead of relying on fastify secrets only

fixes #224 224